### PR TITLE
Fixed multiline label animation issue

### DIFF
--- a/Classes/RQShineLabel.m
+++ b/Classes/RQShineLabel.m
@@ -154,6 +154,9 @@
 {
   CFTimeInterval now = CACurrentMediaTime();
   for (NSUInteger i = 0; i < self.attributedString.length; i ++) {
+    if ([[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:[self.attributedString.string characterAtIndex:i]]) {
+        continue;
+    }
     [self.attributedString enumerateAttribute:NSForegroundColorAttributeName
                                       inRange:NSMakeRange(i, 1)
                                       options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired


### PR DESCRIPTION
Skip whitespace and newline characters animation, as this can sometimes cause the first line of multiline label to jump after the animation is complete