### PR TITLE
Modernize Objective-C syntax

### DIFF
--- a/Example/RQShineLabelDemo.xcodeproj/project.pbxproj
+++ b/Example/RQShineLabelDemo.xcodeproj/project.pbxproj
@@ -13,23 +13,10 @@
 		37B08318191A668C00620618 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 37B08317191A668C00620618 /* main.m */; };
 		37B0831C191A668C00620618 /* RQAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 37B0831B191A668C00620618 /* RQAppDelegate.m */; };
 		37B0831E191A668C00620618 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 37B0831D191A668C00620618 /* Images.xcassets */; };
-		37B08326191A668C00620618 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37B0830B191A668B00620618 /* Foundation.framework */; };
-		37B08327191A668C00620618 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37B0830F191A668C00620618 /* UIKit.framework */; };
 		37B08346191A680800620618 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 37B08343191A680800620618 /* Main.storyboard */; };
 		37B08347191A680800620618 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 37B08345191A680800620618 /* ViewController.m */; };
-		BB58FE682A49532500282C36 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB58FE672A49532500282C36 /* XCTest.framework */; platformFilter = ios; };
 		BB58FE6C2A4953DD00282C36 /* RQShineLabel in Frameworks */ = {isa = PBXBuildFile; productRef = BB58FE6B2A4953DD00282C36 /* RQShineLabel */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		37B08328191A668C00620618 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 37B08300191A668B00620618 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 37B08307191A668B00620618;
-			remoteInfo = RQShineLabelDemo;
-		};
-/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		37B08308191A668B00620618 /* RQShineLabelDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RQShineLabelDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -42,7 +29,6 @@
 		37B0831A191A668C00620618 /* RQAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RQAppDelegate.h; sourceTree = "<group>"; };
 		37B0831B191A668C00620618 /* RQAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RQAppDelegate.m; sourceTree = "<group>"; };
 		37B0831D191A668C00620618 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
-		37B08323191A668C00620618 /* RQShineLabelDemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RQShineLabelDemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		37B08343191A680800620618 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		37B08344191A680800620618 /* ViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
 		37B08345191A680800620618 /* ViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
@@ -58,16 +44,6 @@
 				37B08310191A668C00620618 /* UIKit.framework in Frameworks */,
 				BB58FE6C2A4953DD00282C36 /* RQShineLabel in Frameworks */,
 				37B0830C191A668B00620618 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		37B08320191A668C00620618 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BB58FE682A49532500282C36 /* XCTest.framework in Frameworks */,
-				37B08327191A668C00620618 /* UIKit.framework in Frameworks */,
-				37B08326191A668C00620618 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -87,7 +63,6 @@
 			isa = PBXGroup;
 			children = (
 				37B08308191A668B00620618 /* RQShineLabelDemo.app */,
-				37B08323191A668C00620618 /* RQShineLabelDemoTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -150,24 +125,6 @@
 			productReference = 37B08308191A668B00620618 /* RQShineLabelDemo.app */;
 			productType = "com.apple.product-type.application";
 		};
-		37B08322191A668C00620618 /* RQShineLabelDemoTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 37B08337191A668C00620618 /* Build configuration list for PBXNativeTarget "RQShineLabelDemoTests" */;
-			buildPhases = (
-				37B0831F191A668C00620618 /* Sources */,
-				37B08320191A668C00620618 /* Frameworks */,
-				37B08321191A668C00620618 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				37B08329191A668C00620618 /* PBXTargetDependency */,
-			);
-			name = RQShineLabelDemoTests;
-			productName = RQShineLabelDemoTests;
-			productReference = 37B08323191A668C00620618 /* RQShineLabelDemoTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -178,11 +135,6 @@
 				CLASSPREFIX = RQ;
 				LastUpgradeCheck = 1500;
 				ORGANIZATIONNAME = Reteq;
-				TargetAttributes = {
-					37B08322191A668C00620618 = {
-						TestTargetID = 37B08307191A668B00620618;
-					};
-				};
 			};
 			buildConfigurationList = 37B08303191A668B00620618 /* Build configuration list for PBXProject "RQShineLabelDemo" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -201,7 +153,6 @@
 			projectRoot = "";
 			targets = (
 				37B08307191A668B00620618 /* RQShineLabelDemo */,
-				37B08322191A668C00620618 /* RQShineLabelDemoTests */,
 			);
 		};
 /* End PBXProject section */
@@ -213,13 +164,6 @@
 			files = (
 				37B08346191A680800620618 /* Main.storyboard in Resources */,
 				37B0831E191A668C00620618 /* Images.xcassets in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		37B08321191A668C00620618 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -236,22 +180,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		37B0831F191A668C00620618 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		37B08329191A668C00620618 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 37B08307191A668B00620618 /* RQShineLabelDemo */;
-			targetProxy = 37B08328191A668C00620618 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		37B08332191A668C00620618 /* Debug */ = {
@@ -393,52 +322,6 @@
 			};
 			name = Release;
 		};
-		37B08338191A668C00620618 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/RQShineLabelDemo.app/RQShineLabelDemo";
-				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = "";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "RQShineLabelDemo/RQShineLabelDemo-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = "RQShineLabelDemoTests/RQShineLabelDemoTests-Info.plist";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				TEST_HOST = "$(BUNDLE_LOADER)";
-				WRAPPER_EXTENSION = xctest;
-			};
-			name = Debug;
-		};
-		37B08339191A668C00620618 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/RQShineLabelDemo.app/RQShineLabelDemo";
-				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = "";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "RQShineLabelDemo/RQShineLabelDemo-Prefix.pch";
-				INFOPLIST_FILE = "RQShineLabelDemoTests/RQShineLabelDemoTests-Info.plist";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				TEST_HOST = "$(BUNDLE_LOADER)";
-				WRAPPER_EXTENSION = xctest;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -456,15 +339,6 @@
 			buildConfigurations = (
 				37B08335191A668C00620618 /* Debug */,
 				37B08336191A668C00620618 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		37B08337191A668C00620618 /* Build configuration list for PBXNativeTarget "RQShineLabelDemoTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				37B08338191A668C00620618 /* Debug */,
-				37B08339191A668C00620618 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/RQShineLabelDemo/ViewController.m
+++ b/Example/RQShineLabelDemo/ViewController.m
@@ -20,7 +20,7 @@
 
 @implementation ViewController
 
-- (id)initWithCoder:(NSCoder *)decoder
+- (instancetype)initWithCoder:(NSCoder *)decoder
 {
   if (self = [super initWithCoder:decoder]) {
     _textArray = @[
@@ -56,7 +56,7 @@
   self.shineLabel = ({
     RQShineLabel *label = [[RQShineLabel alloc] initWithFrame:CGRectMake(16, 16, 320 - 32, CGRectGetHeight(self.view.bounds) - 16)];
     label.numberOfLines = 0;
-    label.text = [self.textArray objectAtIndex:self.textIndex];
+    label.text = (self.textArray)[self.textIndex];
     label.font = [UIFont fontWithName:@"HelveticaNeue-Light" size:24.0];
     label.backgroundColor = [UIColor clearColor];
     [label sizeToFit];


### PR DESCRIPTION
This PR includes
 - Removing unused test
 - Modernizing Objective-C syntax

For modernizing objc syntax, I used Xcode's convert featuer (Edit->Convert->To Modern Objective-C Syntax...)

Changes are about replacing `id` with `instancetype` and using dot to access properties rather than square brackets.

For the reason that I changed to `instancetype`, please read [Apple developer docs](https://developer.apple.com/library/archive/releasenotes/ObjectiveC/ModernizationObjC/AdoptingModernObjective-C/AdoptingModernObjective-C.html#//apple_ref/doc/uid/TP40014150-CH1-SW11).

I think dot is better than square brackets since it is similar to Swift syntax.